### PR TITLE
Mitigate code execution by sanitizing device Id

### DIFF
--- a/lib/ios-simulator.js
+++ b/lib/ios-simulator.js
@@ -11,7 +11,10 @@ function Simulator(options) {
 }
 
 Simulator.prototype.setDeviceId = function(deviceId) {
-  this.deviceId = deviceId;
+  if (deviceId.match(/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/))
+  {
+    this.deviceId = deviceId;
+  }
 };
 
 Simulator.prototype.boot = function() {


### PR DESCRIPTION
Since the device Id is taken without any checks, the easy mitigation is to not accept a malformed device ID, and letting it be `undefined`. This disables the program to not take any action as it gives an `Invalid Device: undefined` error.