### PR TITLE
Fix command injection vulnerability

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -13,10 +13,9 @@ _.sleep = function(ms) {
   });
 };
 
-_.exec = function(cmd, opts) {
-  cmd = cmd.replace('"booted"', 'booted');
+_.exec = function(file, args, opts) {
   return new Promise(function(resolve, reject) {
-    childProcess.exec(cmd, _.merge({
+    childProcess.execFile(file, args, _.merge({
       maxBuffer: 1024 * 512,
       wrapArgs: false
     }, opts || {}), function(err, stdout) {
@@ -28,9 +27,8 @@ _.exec = function(cmd, opts) {
   });
 };
 
-_.execSync = function(cmd) {
-  cmd = cmd.replace('"booted"', 'booted');
-  return childProcess.execSync(cmd).toString();
+_.execSync = function(file, args) {
+  return childProcess.execFileSync(file, args).toString();
 };
 
 _.spawn = function() {
@@ -150,14 +148,14 @@ _.getDevicesState = function(devices, id) {
   return state;
 };
 
-_.execPromiseGenerator = function(cmd, cb) {
-  var promise = _.exec(cmd);
+_.execPromiseGenerator = function(file, args, cb) {
+  var promise = _.exec(file, args);
 
   if (cb) {
     return promise.then(data => {
       cb.call(this, null, data);
     }).catch(err => {
-      cb.call(this, `exec ${cmd} error with: ${err}`);
+      cb.call(this, `exec ${file} error with: ${err}`);
     });
   } else {
     return promise;

--- a/lib/ios-simulator.js
+++ b/lib/ios-simulator.js
@@ -16,8 +16,7 @@ Simulator.prototype.setDeviceId = function(deviceId) {
 
 Simulator.prototype.boot = function() {
   var args = Array.prototype.slice.call(arguments);
-  var cmd = `xcrun simctl boot "${this.deviceId}"`;
-  return _.execPromiseGenerator(cmd, args[0]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'boot', this.deviceId], args[0]);
 };
 
 Simulator.prototype.isBooted = function() {
@@ -47,29 +46,25 @@ Simulator.prototype.isBooted = function() {
 
 Simulator.prototype.open = function() {
   var args = Array.prototype.slice.call(arguments);
-  var cmd = `open -a Simulator --args -CurrentDeviceUDID "${this.deviceId}"`;
-  return _.execPromiseGenerator(cmd, args[0]);
+  return _.execPromiseGenerator('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', this.deviceId], args[0]);
 };
 
 Simulator.prototype.shutdown = function() {
   var args = Array.prototype.slice.call(arguments);
-  var cmd = `xcrun simctl shutdown "${this.deviceId}"`;
-  return _.execPromiseGenerator(cmd, args[0]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'shutdown', this.deviceId], args[0]);
 };
 
 Simulator.prototype.install = function() {
   var args = Array.prototype.slice.call(arguments);
   var appPath = args[0];
-  var cmd = `xcrun simctl install "${this.deviceId}" "${appPath}"`;
-  return _.execPromiseGenerator(cmd, args[1]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'install', this.deviceId, appPath], args[1]);
 };
 
 Simulator.prototype.installUntilReady = function() {
   var args = Array.prototype.slice.call(arguments);
   var appPath = args[0];
   var bundleId = args[1];
-  var cmd = `xcrun simctl install "${this.deviceId}" "${appPath}"`;
-  _.execPromiseGenerator(cmd, args[2]).then(() => {});
+  _.execPromiseGenerator('xcrun', ['simctl', 'install', this.deviceId, appPath], args[2]).then(() => {});
 
   var promise = () => {
     return new Promise((resolve, reject) => {
@@ -86,34 +81,29 @@ Simulator.prototype.installUntilReady = function() {
 Simulator.prototype.uninstall = function() {
   var args = Array.prototype.slice.call(arguments);
   var pkg = args[0];
-  var cmd = `xcrun simctl uninstall "${this.deviceId}" "${pkg}"`;
-  return _.execPromiseGenerator(cmd, args[1]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'uninstall', this.deviceId, pkg], args[1]);
 };
 
 Simulator.prototype.launch = function() {
   var args = Array.prototype.slice.call(arguments);
   var appIdentifier = args[0];
-  var cmd = `xcrun simctl launch "${this.deviceId}" "${appIdentifier}"`;
-  return _.execPromiseGenerator(cmd, args[1]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'launch', this.deviceId, appIdentifier], args[1]);
 };
 
 Simulator.prototype.terminate = function() {
   var args = Array.prototype.slice.call(arguments);
   var appIdentifier = args[0];
-  var cmd = `xcrun simctl terminate "${this.deviceId}" "${appIdentifier}"`;
-  return _.execPromiseGenerator(cmd, args[1]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'terminate', this.deviceId, appIdentifier], args[1]);
 };
 
 Simulator.prototype.remove = function() {
-  var cmd = `xcrun simctl delete "${this.deviceId}"`;
-  return _.execSync(cmd);
+  return _.execSync('xcrun', ['simctl', 'delete', this.deviceId]);
 };
 
 Simulator.prototype.openURL = function() {
   var args = Array.prototype.slice.call(arguments);
   var url = args[0];
-  var cmd = `xcrun simctl openurl "${this.deviceId}" "${url}"`;
-  return _.execPromiseGenerator(cmd, args[1]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'openurl', this.deviceId, url], args[1]);
 };
 
 Simulator.prototype.spawn = function(args, opt) {
@@ -126,14 +116,12 @@ Simulator.prototype.spawn = function(args, opt) {
 
 Simulator.prototype.erase = function() {
   var args = Array.prototype.slice.call(arguments);
-  var cmd = `xcrun simctl erase "${this.deviceId}"`;
-  return _.execPromiseGenerator(cmd, args[0]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'erase', this.deviceId], args[0]);
 };
 
 Simulator.prototype.shutdown = function() {
   var args = Array.prototype.slice.call(arguments);
-  var cmd = `xcrun simctl shutdown "${this.deviceId}"`;
-  return _.execPromiseGenerator(cmd, args[0]);
+  return _.execPromiseGenerator('xcrun', ['simctl', 'shutdown', this.deviceId], args[0]);
 };
 
 Simulator.prototype.getLogDir = function() {
@@ -166,8 +154,7 @@ Simulator.prototype.listInstalledApps = function(type) {
 };
 
 Simulator.prototype.exists = function(bundleId) {
-  var cmd = `xcrun simctl get_app_container ${this.deviceId} ${bundleId}`;
-  return _.exec(cmd).then(() => {
+  return _.exec('xcrun', ['simctl', 'get_app_container', this.deviceId, bundleId]).then(() => {
     return true;
   }).catch(() => {
     return false;
@@ -176,13 +163,11 @@ Simulator.prototype.exists = function(bundleId) {
 
 Simulator.getDevices = function() {
   var args = Array.prototype.slice.call(arguments);
-  var cmd = 'xcrun simctl list devices';
-
   var promise = new Promise((resolve, reject) => {
-    _.exec(cmd).then(data => {
+    _.exec('xcrun', ['simctl', 'list', 'devices']).then(data => {
       resolve(_.parseDevices(data));
     }).catch(err => {
-      reject(`exec ${cmd} error with: ${err}`);
+      reject(`exec error with: ${err}`);
     });
   });
 
@@ -199,20 +184,17 @@ Simulator.getDevices = function() {
 };
 
 Simulator.getDevicesSync = () => {
-  var cmd = 'xcrun simctl list devices';
-  const stdout = _.execSync(cmd);
+  const stdout = _.execSync('xcrun', ['simctl', 'list', 'devices']);
   return stdout;
 };
 
 Simulator.killAll = function() {
   var args = Array.prototype.slice.call(arguments);
-  var cmd = 'killAll Simulator';
-  return _.execPromiseGenerator(cmd, args[0]);
+  return _.execPromiseGenerator('killall', ['Simulator'], args[0]);
 };
 
 Simulator.getAvaliableRuntimes = function() {
-  var cmd = 'xcrun simctl list runtimes';
-  const stdout = _.execSync(cmd);
+  const stdout = _.execSync('xcrun', ['simctl', 'list', 'runtimes']);
 
   if (!stdout) {
     return;
@@ -238,18 +220,17 @@ Simulator.getAvaliableRuntimes = function() {
 };
 
 Simulator.getDeviceTypes = () => {
-  const cmd = 'xcrun simctl list devicetypes';
-  return _.execSync(cmd);
+  return _.execSync('xcrun', ['simctl', 'list', 'devicetypes']);
 };
 
 Simulator.create = (name, deviceTypeId, runTimeId) => {
-  const cmd = `xcrun simctl create '${name}' ${deviceTypeId} ${runTimeId}`;
-  return _.execSync(cmd).trim();
+  return _.execSync('xcrun', ['simctl', 'create', name, deviceTypeId, runTimeId]).trim();
 };
 
 Simulator.launchByUDID = (udid) => {
-  const cmd = 'open `xcode-select -p`/Applications/Simulator.app/ --args -CurrentDeviceUDID ' + udid;
-  return _.execSync(cmd);
+  const xcodeStr = _.execSync('xcode-select', ['-p']).trim();
+  return _.execSync('open', [`${xcodeStr}/Applications/Simulator.app/`,
+                            '--args', '-CurrentDeviceUDID', udid]);
 };
 
 const bootedSingleton = new Simulator({


### PR DESCRIPTION
I've replaced all instances of `exec`/`execSync` within the code with `execFile`/`execFileSync`, as it allows us to pass in arguments via an array, which gets automatically sanitized / escaped. Furthermore,  `execFile`/`execFileSync` can be more efficient because it does not spawn a shell by default.